### PR TITLE
Convert CRLF to LF.

### DIFF
--- a/DotaBot/DotaCommands.cs
+++ b/DotaBot/DotaCommands.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/DotaBot/DotaUtils.cs
+++ b/DotaBot/DotaUtils.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Collections;

--- a/DotaBot/Entities/Ability.cs
+++ b/DotaBot/Entities/Ability.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;

--- a/DotaBot/Entities/Hero.cs
+++ b/DotaBot/Entities/Hero.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Newtonsoft.Json;
 

--- a/DotaBot/Entities/History.cs
+++ b/DotaBot/Entities/History.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using Newtonsoft.Json;

--- a/DotaBot/Program.cs
+++ b/DotaBot/Program.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading.Tasks;
 using DSharpPlus;

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# DotaBot
+------
+
+DotaBot is a Discord bot designed to give you information about Dota heroes as well as show stats for players.
+
+If it doesn't work, blame the maintainer! He didn't include a file. And now, a short poem.
+
+```
+I play dota,
+bees live in a hive.
+you suck at dota,
+ez mmr +25.
+```


### PR DESCRIPTION
CRLF sequences, typically used to delimit lines in DOS systems, can be problematic for those on other system architectures which only use LF. Most open-source projects opt to use LF, as it is the most common standard.

This PR converts all the code's CRLFs to LFs to improve compatibility with other systems, as well as adding a readme.